### PR TITLE
Fix Scaffold::updatePackageArray calling

### DIFF
--- a/src/Support/Scaffold.php
+++ b/src/Support/Scaffold.php
@@ -36,8 +36,7 @@ abstract class Scaffold
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 
         $packages[$configurationKey] = static::updatePackageArray(
-            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : [],
-            $configurationKey
+            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : []
         );
 
         ksort($packages[$configurationKey]);


### PR DESCRIPTION
> Static method Bazar\Support\Scaffold::updatePackageArray() invoked with 2 parameters, 1 required.

I was in the "eye-shop" and I've noticed that `updatePackageArray` [has a problem](https://github.com/thepinecode/bazar/blob/c1053298a2c60d7a87811e7f87055c75feb70beb/src/Support/Scaffold.php#L65-L71).