### PR TITLE
[Fix] Checking differences between variant and selected option is too permissive

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -182,7 +182,7 @@ class Product extends Model implements Breadcrumbable, Contract, Stockable
                 }
             }
 
-            return empty(array_diff(array_intersect_key($variant->option, $option), $option));
+            return empty(array_diff_assoc(array_intersect_key($variant->option, $option), $option));
         });
     }
 


### PR DESCRIPTION
I'm exploring Bazar and i'm currently experiencing an issue when I select variants.

I have 2 variants, `Height` and `Width`, with each having `100`, `200`, `300` values. When i choose : 
- `["Height" => "100", "Width" => "100"]`, everything good, the variant is found,
- but when i selected `["Height" => "100", "Width" => "200"]`, it still find the variant, and it shouldn't.

I didn't understand why at first, but this is due because `array_diff` only checking value, without using key. The REPL should clarify : https://www.tehplayground.com/M9znqZ85tdAXLEJI 

So we should checking if there is any difference in `key => value` and using `array_intersect_key` is fixing that.
