### PR TITLE
lowercase currency to avoid mismatch with the seeders factory

### DIFF
--- a/config/bazar.php
+++ b/config/bazar.php
@@ -32,8 +32,8 @@ return [
     'currencies' => [
         'default' => strtolower(env('BAZAR_CURRENCY', 'usd')),
         'available' => [
-            'usd' => 'USD',
-            'eur' => 'EUR',
+            'usd' => 'usd',
+            'eur' => 'eur',
         ],
     ],
 


### PR DESCRIPTION
the factory uses lower case currency codes, if the config is set to uppercase multiple price array's are created.