### PR TITLE
Remove L11 from CI

### DIFF
--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: ["ubuntu-24.04"]
         php: ["8.3", "8.4"]
-        laravel: ["^11.0", "^12.0"]
+        laravel: ["^12.0"]
         dependency-version: ["highest"]
 
     name: "Unit - PHP ${{ matrix.php }} - L ${{ matrix.laravel }} - ${{ matrix.dependency-version }}"
@@ -51,7 +51,7 @@ jobs:
         run: composer exec -- phpunit
 
       - name: Send coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.php == '8.3' && matrix.laravel == '^11.0' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.php == '8.3' && matrix.laravel == '^12.0' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
An open-source package would support a bit more than one Laravel version.
Many packages for Laravel support `^10.0 || ^11.0 || ^12.0`

https://github.com/conedevelopment/bazar/blob/cb0f99698a9ee7b5328508dee8b2ba6053f846af/composer.json#L30